### PR TITLE
Add filter on select fields in ajax query

### DIFF
--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -203,23 +203,51 @@ class acf_field_select extends acf_field {
 		}
 		
 		
-		// loop 
+				$has_search_filter = false;
+		if (
+			has_filter('acf/fields/select/search') ||
+			has_filter('acf/fields/select/search/name=' . $field['name']) ||
+			has_filter('acf/fields/select/search/key=' . $field['key'])
+		) {
+			$has_search_filter = true;
+		}
+
+		// loop
 		foreach( $field['choices'] as $k => $v ) {
-			
+
 			// ensure $v is a string
 			$v = strval( $v );
-			
-			
+
 			// if searching, but doesn't exist
-			if( is_string($s) && stripos($v, $s) === false ) continue;
-			
-			
+			if ( is_string($s) ) {
+				$include = null;
+
+				if ( $has_search_filter ) {
+					$search_args = array(
+						'value' => $k,
+						'label' => $v,
+						's' => $s
+					);
+
+					$include = apply_filters('acf/fields/select/search', $include, $search_args, $field, $options['post_id'] );
+					$include = apply_filters('acf/fields/select/search/name=' . $field['name'], $include, $search_args, $field, $options['post_id'] );
+					$include = apply_filters('acf/fields/select/search/key=' . $field['key'], $include, $search_args, $field, $options['post_id'] );
+
+				}
+
+				if ( $include === null && stripos($v, $s) === false ) {
+					continue;
+				} else if ($include === false) {
+					continue;
+				}
+			}
+
 			// append
 			$results[] = array(
 				'id'	=> $k,
 				'text'	=> $v
 			);
-			
+
 		}
 		
 		


### PR DESCRIPTION
This allows for custom search functionality.

We sometimes use the select fields with dynamic data in combination with an external API. This generally works great!

If the API supports search it makes sense to forward `$_POST['s']` to this API. The build in filter however does a very simplistic `stripos` validation on the label of the `choices`. A more sophisticated search might include an item because it matched all terms found in `$_POST['s']` but in a different order.

This change allows implementers to modify or disable the build in filter on `$_POST['s']`.

Examples :

```php
// disable acf filter on $_POST['s']
add_filter(
	'acf/fields/select/search/name=<my field>',
	function( $include, $args, $field, $post_id ) {
		return true;
	},
	10,
	4
);
```

```php
// look for individual words by splitting on spaces in $_POST['s']
add_filter(
	'acf/fields/select/search',
	function( $include, $args, $field, $post_id ) {
		$label = $args['label'];
		$s = $args['s'];

		$terms = explode(" ", $s);
		foreach ($terms as $term) {
			if (stripos($label, $term) !== false) {
				return true;
			}
		}

		return false;
	},
	10,
	4
);
```